### PR TITLE
Add a token service

### DIFF
--- a/api/MatchSpark.API/Program.cs
+++ b/api/MatchSpark.API/Program.cs
@@ -5,6 +5,8 @@ using Microsoft.EntityFrameworkCore;
 using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
+using MatchSpark.Core.Interfaces;
+using MatchSpark.Core.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 var jwtSettings = builder.Configuration.GetSection("JwtSettings");
@@ -23,6 +25,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 builder.Services.AddControllers();
 builder.Services.AddDbContext<ApplicationDbContext>(options => options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 builder.Services.AddScoped<UserServices>();
+builder.Services.AddScoped<ITokenService, TokenService>();
 
 var app = builder.Build();
 

--- a/api/MatchSpark.Core.Tests/Services/TokenServiceTests.cs
+++ b/api/MatchSpark.Core.Tests/Services/TokenServiceTests.cs
@@ -1,0 +1,38 @@
+using MatchSpark.Core.Entities;
+using MatchSpark.Core.Services;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using System;
+using Xunit;
+
+namespace MatchSpark.Core.Tests.Services
+{
+    public class TokenServiceTests
+    {
+        private readonly TokenService _tokenService;
+        private readonly Mock<IConfiguration> _configMock;
+
+        public TokenServiceTests()
+        {
+            _configMock = new Mock<IConfiguration>();
+            var jwtSectionMock = new Mock<IConfigurationSection>();
+            jwtSectionMock.Setup(s => s["Secret"]).Returns("MyVerySecretKeyHerefadsffffffffffffadsfdsssssssssssssssssssssssssssssssssssssssssssssssssssssssssssewafewfewfqqgqrrfwhtejjyryjry");
+            _configMock.Setup(c => c.GetSection("JwtSettings")).Returns(jwtSectionMock.Object);
+            _tokenService = new TokenService(_configMock.Object);
+        }
+
+        [Fact]
+        public void CreateToken_ReturnsNonNullTokenForValidUser()
+        {
+            // Arrange
+            var user = new AppUser { Email = "test@example.com", PasswordHash = "123456" };
+
+            // Act
+            var token = _tokenService.CreateToken(user);
+
+            // Assert
+            Assert.NotNull(token);
+            Assert.NotEmpty(token);
+        }
+    }
+}

--- a/api/MatchSpark.Core.Tests/Services/UserServiceTests.cs
+++ b/api/MatchSpark.Core.Tests/Services/UserServiceTests.cs
@@ -24,8 +24,8 @@ namespace MatchSpark.Core.Tests.Services
                 AppUser user = new AppUser { Email = "test@example.com" };
                
                 // Act
-                bool result = await service.RegisterUserAsync(user, "TestPassword123!");
-                Assert.True(result);
+                var result = await service.RegisterUserAsync(user, "TestPassword123!");
+                Assert.True(result.Success);
             }
         }
     }

--- a/api/MatchSpark.Core/Interfaces/ITokenService.cs
+++ b/api/MatchSpark.Core/Interfaces/ITokenService.cs
@@ -1,0 +1,9 @@
+using MatchSpark.Core.Entities;
+
+namespace MatchSpark.Core.Interfaces
+{
+    public interface ITokenService
+    {
+        string CreateToken(AppUser user);
+    }
+}

--- a/api/MatchSpark.Core/MatchSpark.Core.csproj
+++ b/api/MatchSpark.Core/MatchSpark.Core.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.2" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.4.0" />
   </ItemGroup>
 
 </Project>

--- a/api/MatchSpark.Core/Services/TokenService.cs
+++ b/api/MatchSpark.Core/Services/TokenService.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using MatchSpark.Core.Entities;
+using MatchSpark.Core.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+
+namespace MatchSpark.Core.Services
+{
+    public class TokenService : ITokenService
+    {
+        private readonly IConfiguration _configuration;
+        public TokenService(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public string CreateToken(AppUser user)
+        {
+            var jwtSettings = _configuration.GetSection("JwtSettings");
+            var secretKey = Encoding.UTF8.GetBytes(jwtSettings["Secret"]);
+            var claims = new List<Claim> 
+            {
+                new Claim(JwtRegisteredClaimNames.Email, user.Email)
+            };
+
+            var key = new SymmetricSecurityKey(secretKey);
+            var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha512Signature);
+
+            var tokenDescriptor = new SecurityTokenDescriptor
+            {
+                Subject = new ClaimsIdentity(claims),
+                Expires = DateTime.Now.AddDays(7),
+                SigningCredentials = creds
+            };
+
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var token = tokenHandler.CreateToken(tokenDescriptor);
+
+            return tokenHandler.WriteToken(token);
+        }
+    }
+}


### PR DESCRIPTION
- Add an interface called ITokenService to create a new token.
- Add a tokenService class which inherits from ITokenService the iner file that contains a function called CreateToken that receives an AppUser and generates a token for it.
- Add the token service to program.cs.
- Fix the test for registering a new user to the application.
- Add a file named TokenServiceTests.cs that includes a test to create a token correctly